### PR TITLE
#158787482 Improve Gradle Build Speed

### DIFF
--- a/app/src/main/java/com/example/androidcodelabapp/view/MainActivity.java
+++ b/app/src/main/java/com/example/androidcodelabapp/view/MainActivity.java
@@ -11,6 +11,7 @@ import android.content.Intent;
 import android.view.View;
 import android.widget.ProgressBar;
 
+
 import com.example.androidcodelabapp.R;
 import com.example.androidcodelabapp.adapter.GithubUsersAdapter;
 import com.example.androidcodelabapp.model.GithubUsers;

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,5 +11,9 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+org.gradle.cache=true
+org.gradle.daemon=true
+
+
 
 


### PR DESCRIPTION
### What does this PR do?
The PR involves Improving the Gradle build Speed using Gradle build cache for Android

### Description of the task
- Enable cache in grade.properties

### How can the Task be tested
- Check for the presence of enabled cached setting

### Relevant pivotal tracker story
[#158787482](https://www.pivotaltracker.com/story/show/158787482)

### Screenshots:
#### Speed without build cache
<img width="1395" alt="Screen Shot 2019-04-05 at 2 59 07 PM" src="https://user-images.githubusercontent.com/42971167/55626166-72e6c680-57b3-11e9-806b-48a40b47d097.png">

<img width="409" alt="Screen Shot 2019-04-05 at 4 35 34 PM" src="https://user-images.githubusercontent.com/42971167/55631737-69fcf180-57c1-11e9-8160-6d4846469292.png">


### Speed with build cache
<img width="1410" alt="Screen Shot 2019-04-05 at 3 06 02 PM" src="https://user-images.githubusercontent.com/42971167/55626536-77f84580-57b4-11e9-8744-6508616cabb8.png">

<img width="416" alt="Screen Shot 2019-04-05 at 4 36 51 PM" src="https://user-images.githubusercontent.com/42971167/55631771-7aad6780-57c1-11e9-8a86-0242424af30c.png">





